### PR TITLE
Copy files instead of linking and add binary file support

### DIFF
--- a/cli/install-self.ts
+++ b/cli/install-self.ts
@@ -12,10 +12,15 @@ import * as path from 'path'
   const packageNodeModuleDirectory = path.join('node_modules', packageJson.name);
   const filenames = await packlist();
 
+  await FileSystem.remove(packageNodeModuleDirectory);
+
   await Promise.all(
       filenames.map(async filename => {
           await FileSystem.ensureDir(path.join(packageNodeModuleDirectory, path.dirname(filename)));
-          await FileSystem.copyFile(filename, path.join(packageNodeModuleDirectory, filename));
+          await FileSystem.symlink(
+              path.relative(path.join(packageNodeModuleDirectory, path.dirname(filename)), filename),
+              path.join(packageNodeModuleDirectory, filename)
+          );
       })
   );
 

--- a/cli/install-self.ts
+++ b/cli/install-self.ts
@@ -5,12 +5,11 @@ import * as packlist from "npm-packlist";
 import * as path from 'path'
 
 (async () => {
-  const packageDirectory = process.cwd();
 
   // get package name
-  const packageJson = require(path.resolve(packageDirectory, 'package.json'));
+  const packageJson = require(path.resolve(process.cwd(), 'package.json'));
 
-  const packageNodeModuleDirectory = path.join(packageDirectory, 'node_modules', packageJson.name);
+  const packageNodeModuleDirectory = path.join('node_modules', packageJson.name);
   const filenames = await packlist();
 
   await Promise.all(
@@ -24,12 +23,12 @@ import * as path from 'path'
       Object.keys(packageJson.bin || {})
           .map(async name => {
               const filename = packageJson.bin[name]
-              await FileSystem.ensureDir(path.join(packageDirectory, 'node_modules', '.bin'));
-              await FileSystem.copyFile(
-                path.join(packageNodeModuleDirectory, filename),
-                path.join(packageDirectory, 'node_modules', '.bin', name)
+              await FileSystem.ensureDir(path.join('node_modules', '.bin'));
+              await FileSystem.remove(path.join('node_modules', '.bin', name))
+              await FileSystem.symlink(
+                path.relative(path.join('node_modules', '.bin'), path.join(packageNodeModuleDirectory, filename)),
+                path.join('node_modules', '.bin', name)
               );
-              await FileSystem.chmod(path.join(packageDirectory, 'node_modules', '.bin', name), '755')
           })
   )
 

--- a/package.json
+++ b/package.json
@@ -30,8 +30,14 @@
   },
   "homepage": "https://github.com/jamesrichford/install-self#readme",
   "devDependencies": {
+    "@types/fs-extra": "^8.0.0",
     "@types/node": "0.0.2",
+    "@types/npm-packlist": "^1.1.1",
     "alsatian": "^1.0.0-beta.4",
     "typescript": "^2.0.10"
+  },
+  "dependencies": {
+    "fs-extra": "^8.1.0",
+    "npm-packlist": "^1.4.6"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
       "preserveConstEnums": true,
       "experimentalDecorators": true,
       "emitDecoratorMetadata": true,
-      "newLine": "LF"
+      "newLine": "LF",
+      "lib": ["es2015"]
    },
    "buildOnSave": false,
    "compileOnSave": true,


### PR DESCRIPTION
I like the idea of this package, so I improved it a bit in this PR:

In the current version only the main file is linked. In order to test the package as realistic as possible, it makes sense to have the files copied into node_modules that would be published with `npm publish`. [npm-packlist](https://www.npmjs.com/package/npm-packlist) does this. The rest is copying the files async.

The other improvement is binary files. Now binaries declared in the `bin` section of `package.json` are linked into `node_modules/.bin`.